### PR TITLE
build.gradle에서 openapi3 관련 스크립트 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,9 @@ tasks.register("copyTextToSecurity") {
     doLast {
         def openapi3File = file(openapi3Path)
         def securityFile = file("src/test/resources/security.yaml")
-        openapi3File.append securityFile.text
+        if (!openapi3File.text.contains("securitySchemes")) {
+            openapi3File.append securityFile.text
+        }
     }
 }
 

--- a/src/test/resources/security.yaml
+++ b/src/test/resources/security.yaml
@@ -3,5 +3,3 @@
       type: http
       scheme: bearer
       bearerFormat: JWT
-security:
-  - bearerAuth: []


### PR DESCRIPTION
- securitySchema 문자열이 있는지 체크하는 로직을 추가했습니다.
- 또, 전역으로 security 설정을 하지 않도록 security.yaml 파일을 수정했습니다.

close #114