### PR TITLE
ActuatorHealthIndicator 추가

### DIFF
--- a/src/main/java/com/coolpeace/global/config/ActuatorHealthIndicator.java
+++ b/src/main/java/com/coolpeace/global/config/ActuatorHealthIndicator.java
@@ -1,0 +1,32 @@
+package com.coolpeace.global.config;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+@Component
+public class ActuatorHealthIndicator implements HealthIndicator {
+
+    private static final String LOCAL_DATE_TIME_KOR_FORMAT = "yyyy년 MM월 dd일 HH시 mm분 ss초";
+
+    private final LocalDateTime serverStartLocalDateTime = LocalDateTime.now();
+
+    @Override
+    public Health getHealth(boolean includeDetails) {
+        long millis = serverStartLocalDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        long uptime = (System.currentTimeMillis() - millis) / 1000;
+        return Health.up()
+                .withDetail("startDate", serverStartLocalDateTime.format(DateTimeFormatter.ofPattern(LOCAL_DATE_TIME_KOR_FORMAT)))
+                .withDetail("uptime", uptime)
+                .build();
+    }
+
+    @Override
+    public Health health() {
+        return getHealth(true);
+    }
+}


### PR DESCRIPTION
- 서버가 언제 실행됐는지 actuator health 정보에서 볼 수 있도록 커스텀 인디케이터를 추가했습니다.
- `/actuator/health` url로 접속 시 서버 시작 시간을 볼 수 있습니다.